### PR TITLE
Fix Trainer.restore_exp()

### DIFF
--- a/yapt/trainer/trainer.py
+++ b/yapt/trainer/trainer.py
@@ -355,7 +355,7 @@ class Trainer(BaseTrainer):
 
         if is_dict(self._model.optimizer):
             for key in self._model.optimizer.keys():
-                self._model.optimizer.load_state_dict(
+                self._model.optimizer[key].load_state_dict(
                     checkpoint['optimizer_state_dict'][key])
         else:
             self._model.optimizer.load_state_dict(


### PR DESCRIPTION
If self._model_optimizer is a dict, it has no `load_state_dict()` method. For loading each optimizer it is necessary to access the dictionary by using` self._model.optimizer[key]` first, and then use the `load_state_dict()` method.